### PR TITLE
Debug menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,11 @@ ifeq ($(DINFO),1)
 override CFLAGS += -g
 endif
 
+ifeq ($(DDEBUG), 1)
+override ASFLAGS += --defsym DEBUG=1
+override CPPFLAGS += -D DEBUG=1
+endif
+
 # The dep rules have to be explicit or else missing files won't be reported.
 # As a side effect, they're evaluated immediately instead of when the rule is invoked.
 # It doesn't look like $(shell) can be deferred so there might not be a better way.

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ ifeq ($(DINFO),1)
 override CFLAGS += -g
 endif
 
-ifeq ($(DDEBUG), 1)
+ifeq ($(DEBUG_MODE), 1)
 override ASFLAGS += --defsym DEBUG=1
 override CPPFLAGS += -D DEBUG=1
 endif

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,0 +1,8 @@
+#ifndef GUARD_DEBUG_H
+#define GUARD_DEBUG_H
+#if DEBUG
+
+void Debug_ShowMainMenu(void);
+
+#endif
+#endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,124 @@
+#if DEBUG
+
+#include "global.h"
+#include "list_menu.h"
+#include "main.h"
+#include "menu.h"
+#include "script.h"
+#include "sound.h"
+#include "strings.h"
+#include "task.h"
+#include "constants/songs.h"
+
+#define DEBUG_MAIN_MENU_HEIGHT 7
+#define DEBUG_MAIN_MENU_WIDTH 11
+
+void Debug_ShowMainMenu(void);
+static void Debug_DestroyMainMenu(u8);
+static void DebugAction_Cancel(u8);
+static void DebugTask_HandleMainMenuInput(u8);
+
+enum {
+    DEBUG_MENU_ITEM_CANCEL,
+};
+
+static const u8 gDebugText_Cancel[] = _("cancel");
+
+static const struct ListMenuItem sDebugMenuItems[] =
+{
+    [DEBUG_MENU_ITEM_CANCEL] = {gDebugText_Cancel, DEBUG_MENU_ITEM_CANCEL}
+};
+
+static void (*const sDebugMenuActions[])(u8) =
+{
+    [DEBUG_MENU_ITEM_CANCEL] = DebugAction_Cancel
+};
+
+static const struct WindowTemplate sDebugMenuWindowTemplate = 
+{
+    .bg = 0,
+    .tilemapLeft = 1,
+    .tilemapTop = 1,
+    .width = DEBUG_MAIN_MENU_WIDTH,
+    .height = 2 * DEBUG_MAIN_MENU_HEIGHT,
+    .paletteNum = 15,
+    .baseBlock = 1,
+};
+
+static const struct ListMenuTemplate sDebugMenuListTemplate =
+{
+    .items = sDebugMenuItems,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenuItems),
+    .maxShowed = DEBUG_MAIN_MENU_HEIGHT,
+    .windowId = 0,
+    .header_X = 0,
+    .item_X = 8,
+    .cursor_X = 0,
+    .upText_Y = 1,
+    .cursorPal = 2,
+    .fillValue = 1,
+    .cursorShadowPal = 3,
+    .lettersSpacing = 1,
+    .itemVerticalPadding = 0,
+    .scrollMultiple = LIST_NO_MULTIPLE_SCROLL,
+    .fontId = 1,
+    .cursorKind = 0
+};
+
+void Debug_ShowMainMenu(void)
+{
+    struct ListMenuTemplate menuTemplate;
+    u8 windowId;
+    u8 menuTaskId;
+    u8 inputTaskId;
+
+    windowId = AddWindow(&sDebugMenuWindowTemplate);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    menuTemplate = sDebugMenuListTemplate;
+    menuTemplate.windowId = windowId;
+    menuTaskId = ListMenuInit(&menuTemplate, 0, 0);
+
+    CopyWindowToVram(windowId, 3);
+
+    inputTaskId = CreateTask(DebugTask_HandleMainMenuInput, 3);
+    gTasks[inputTaskId].data[0] = menuTaskId;
+    gTasks[inputTaskId].data[1] = windowId;
+}
+
+static void Debug_DestroyMainMenu(u8 taskId)
+{
+    DestroyListMenuTask(gTasks[taskId].data[0], NULL, NULL);
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+    DestroyTask(taskId);
+    ScriptContext_Enable();
+}
+
+static void DebugTask_HandleMainMenuInput(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if(gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if((func = sDebugMenuActions[input]) != NULL)
+        {
+            func(taskId);
+        }
+    }
+    else if(gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMainMenu(taskId);
+    }
+}
+
+static void DebugAction_Cancel(u8 taskId)
+{
+    Debug_DestroyMainMenu(taskId);
+}
+
+#endif

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -35,6 +35,8 @@
 #include "constants/songs.h"
 #include "constants/trainer_hill.h"
 
+#include "debug.h"
+
 static EWRAM_DATA u8 sWildEncounterImmunitySteps = 0;
 static EWRAM_DATA u16 sPrevMetatileBehavior = 0;
 
@@ -129,6 +131,15 @@ void FieldGetPlayerInput(struct FieldInput *input, u16 newKeys, u16 heldKeys)
         input->dpadDirection = DIR_WEST;
     else if (heldKeys & DPAD_RIGHT)
         input->dpadDirection = DIR_EAST;
+
+#if DEBUG
+    if((heldKeys & R_BUTTON) && input->pressedStartButton)
+    {
+        input->input_field_1_2 = TRUE;
+        input->pressedStartButton = FALSE;
+    }
+#endif
+
 }
 
 int ProcessPlayerFieldInput(struct FieldInput *input)
@@ -187,6 +198,15 @@ int ProcessPlayerFieldInput(struct FieldInput *input)
     }
     if (input->pressedSelectButton && UseRegisteredKeyItemOnField() == TRUE)
         return TRUE;
+
+#if DEBUG
+    if(input->input_field_1_2)
+    {
+        PlaySE(SE_PC_LOGIN);
+        Debug_ShowMainMenu();
+        return TRUE;
+    }
+#endif
 
     return FALSE;
 }

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -3,6 +3,7 @@
 #include "bike.h"
 #include "coord_event_weather.h"
 #include "daycare.h"
+#include "debug.h"
 #include "faraway_island.h"
 #include "event_data.h"
 #include "event_object_movement.h"
@@ -35,7 +36,6 @@
 #include "constants/songs.h"
 #include "constants/trainer_hill.h"
 
-#include "debug.h"
 
 static EWRAM_DATA u8 sWildEncounterImmunitySteps = 0;
 static EWRAM_DATA u16 sPrevMetatileBehavior = 0;


### PR DESCRIPTION
Adds a debug mode to the project

## Description
You can now enable debug mode by using the compile flag `DEBUG_MODE`.  
It will enable the usage of the `DEBUG` preprocessor flag and enables a debug menu ingame to access variables or functions. It is only the outer shell and doesn't provide any further functionality yet.

![image](https://github.com/user-attachments/assets/773218f6-d8b4-4691-b9d3-252be9819933)
